### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Use Node.js LTS version with Alpine for a lightweight image
+FROM node:18-alpine AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package.json package-lock.json ./
+
+# Install the project dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine AS production
+
+# Set the working directory
+WORKDIR /app
+
+# Copy only the build output and package files
+COPY --from=builder /app/build /app/build
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+# Install only production dependencies
+RUN npm install --production
+
+# Environment variables
+ENV RAYGUN_PAT_TOKEN=your-pat-token-here
+
+# Command to run the application
+ENTRYPOINT ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Raygun MCP Server
 
+![smithery badge](https://smithery.ai/badge/@raygun.io/mcp-server-raygun)
+
 MCP Server for Raygun's API V3 endpoints for interacting with your Crash Reporting and Real User Monitoring applications. This server provides comprehensive access to Raygun's API features through the Model Context Protocol.
 
 ## Features
@@ -112,6 +114,14 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
     }
   }
 }
+```
+
+### Installing via Smithery
+
+To install Raygun Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@raygun.io/mcp-server-raygun):
+
+```bash
+npx -y @smithery/cli install @raygun.io/mcp-server-raygun --client claude
 ```
 
 ### Debugging

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - raygunPatToken
+    properties:
+      raygunPatToken:
+        type: string
+        description: The Raygun PAT token for authenticating API requests.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['build/index.js'], env: { RAYGUN_PAT_TOKEN: config.raygunPatToken } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai) to render configurations for the end-user. It also allows you to deploy your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@raygun.io/mcp-server-raygun), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂